### PR TITLE
Chore: load `./static/media.json` in store and use globaly

### DIFF
--- a/components/ContentImage.vue
+++ b/components/ContentImage.vue
@@ -1,10 +1,8 @@
 <template>
   <responsive-image
     class="mb-2 object-contain rounded-lg mx-auto"
-    :alt="alt"
     :hight="hight"
     :picture="picture"
-    :title="title"
     :width="width"
   />
 </template>
@@ -14,10 +12,8 @@ import ResponsiveImage from './ResponsiveImage.vue'
 export default {
   components: { ResponsiveImage },
   props: {
-    alt: { type: String, default: '' },
     hight: { type: String, default: 'h-100' },
     picture: { type: String, default: '', required: true },
-    title: { type: String, default: '' },
     width: { type: String, default: 'w-100' },
   },
 }

--- a/components/ContentImageGallery.vue
+++ b/components/ContentImageGallery.vue
@@ -22,8 +22,8 @@ export default {
   },
   computed: {
     imageGalery() {
-      return Object.values(this.$store.state.media).map((img) => {
-        return img.path === this.path ? img : ''
+      return Object.values(this.$store.state.media).filter((img) => {
+        return img.path === this.path
       })
     },
   },

--- a/components/ContentImageGallery.vue
+++ b/components/ContentImageGallery.vue
@@ -15,20 +15,14 @@
 
 <script>
 import ResponsiveImage from './ResponsiveImage.vue'
-import media from '~/static/media.json'
 export default {
   components: { ResponsiveImage },
   props: {
     path: { type: String, default: '/media' },
   },
-  data() {
-    return {
-      media,
-    }
-  },
   computed: {
     imageGalery() {
-      return Object.values(this.media).map((img) => {
+      return Object.values(this.$store.state.media).map((img) => {
         return img.path === this.path ? img : ''
       })
     },

--- a/components/ResponsiveImage.vue
+++ b/components/ResponsiveImage.vue
@@ -1,29 +1,34 @@
 <template>
   <img
-    :src="responsive_picture"
+    class="cursor-pointer"
+    :src="responsiveUrl"
     :width="width"
-    :height="hight"
-    :alt="alt"
-    :title="title"
+    :height="height"
+    :alt="imageInformation['alt']"
+    :title="imageInformation['title']"
   />
 </template>
 
 <script>
 export default {
   props: {
-    alt: { type: String, default: '' },
-    hight: { type: String, default: '' },
+    height: { type: String, default: '' },
     picture: { type: String, default: '', required: true },
-    title: { type: String, default: '' },
     width: { type: String, default: '' },
   },
   computed: {
-    responsive_picture() {
-      const extension = this.picture?.split('.')?.reverse()[0]
+    imageInformation() {
+      const images = Object.values(this.$store.state.media).filter((img) => {
+        return img.url === this.picture
+      })
+      return images.length === 1 ? images[0] : { alt: '', title: '', url: '' }
+    },
+    responsiveUrl() {
+      const extension = this.imageInformation.url?.split('.')?.reverse()[0]
       if (process.env.NODE_ENV === 'development' || extension === undefined) {
-        return this.picture
+        return this.imageInformation.url
       }
-      return this.picture.replace(
+      return this.imageInformation.url.replace(
         `.${extension}`,
         `_${this.$store.state.windowWidth}.${extension}`
       )

--- a/components/ResponsiveImage.vue
+++ b/components/ResponsiveImage.vue
@@ -1,5 +1,6 @@
 <template>
   <img
+    v-if="responsiveUrl != ''"
     class="cursor-pointer"
     :src="responsiveUrl"
     :width="width"

--- a/components/TeamMember.vue
+++ b/components/TeamMember.vue
@@ -9,8 +9,6 @@
       <responsive-image
         v-if="picture !== ''"
         class="mb-2 object-contain rounded-lg mx-auto md:m-2"
-        :alt="name"
-        :title="name"
         :picture="picture"
         width="400"
         hight="300"

--- a/content/markdown.md
+++ b/content/markdown.md
@@ -32,7 +32,7 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 
 ### ContentImage.vue
 
-<content-image title="Team Flugschule" alt="Menschen vor der Flugschule" picture="/media/team/team.jpg"></content-image>
+<content-image picture="/media/team/team.jpg"></content-image>
 
 ### ContentImageGallery.vue
 

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "lint:js": "eslint --fix  --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "npm run lint:js",
     "generateMediaInformation": "node generateMediaInformation.js",
-    "optimize-images:sm": "./image-optimizer ./static/media ./dist/media sm 640 90",
-    "optimize-images:md": "./image-optimizer ./static/media ./dist/media md 768 90",
-    "optimize-images:lg": "./image-optimizer ./static/media ./dist/media lg 1024 90",
-    "optimize-images:xl": "./image-optimizer ./static/media ./dist/media xl 1280 90",
-    "optimize-images:2xl": "./image-optimizer ./static/media ./dist/media 2xl 1536 90",
+    "optimize-images:sm": "./image-optimizer ./static/media ./dist/media sm 640 75",
+    "optimize-images:md": "./image-optimizer ./static/media ./dist/media md 768 75",
+    "optimize-images:lg": "./image-optimizer ./static/media ./dist/media lg 1024 75",
+    "optimize-images:xl": "./image-optimizer ./static/media ./dist/media xl 1280 75",
+    "optimize-images:2xl": "./image-optimizer ./static/media ./dist/media 2xl 1536 75",
     "optimize-images": "npm run optimize-images:sm && npm run optimize-images:md && npm run optimize-images:lg && npm run optimize-images:xl && npm run optimize-images:2xl"
   },
   "dependencies": {

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,7 @@
+import media from '~/static/media.json'
+
 export const state = () => ({
+  media,
   windowWidth: 'lg',
 })
 


### PR DESCRIPTION
The image information is now stored in the store. The information is provided by the file `./static/media.json`.

The image quality was reduced from 90 to 75 according to [https://web.dev/](https://web.dev/).